### PR TITLE
Run Sequence + Watch Task Fix

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,6 +9,7 @@ var $ = require('gulp-load-plugins')(),
 	del = require('del'),
 	fs = require('fs'),
 	pngquant = require('imagemin-pngquant'),
+	runSequence = require('run-sequence'),
 	browserSync = require('browser-sync'),
 	reload = browserSync.reload,
 
@@ -109,13 +110,13 @@ gulp.task('clean', function() {
 });
 
 // Manual Default task - does everything
-gulp.task('default', ['clean'], function() {
-	gulp.start('styles', 'scripts', 'vendorScripts', 'imgmin');
+gulp.task('default', ['clean'], function(cb) {
+    runSequence('styles', ['scripts', 'vendorScripts'], 'imgmin', cb);
 });
 
 // Watch and auto-reload browser(s).
 gulp.task('watch', ['browser-sync'], function() {
-	gulp.watch(basePaths.src + 'scss/*.scss', ['styles', reload]);
-	gulp.watch(basePaths.src + 'js/*.js', ['scripts', reload]);
-	gulp.watch([basePaths.dest * '*.html', basePaths.dest + '*.php'], reload);
+  gulp.watch('assets/scss/*.scss', ['styles', reload]);
+  gulp.watch('assets/js/*.js', ['scripts', reload]);
+	gulp.watch([basePaths.dest + '*.html', basePaths.dest + '*.php'], reload);
 });

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "gulp-scss-lint": "^0.1.7",
     "gulp-size": "^1.2.0",
     "gulp-uglify": "^1.1.0",
-    "imagemin-pngquant": "^4.0.0"
+    "imagemin-pngquant": "^4.0.0",
+    "run-sequence": "^1.0.2"
   }
 }


### PR DESCRIPTION
## Run Sequence (Gulp)

* I've added the NPM Run Sequence module to our build process. This allows greater control over the order and timings of when our tasks run. For example, we're now running our Styles task, then running our Scripts and Vendor Scripts tasks in parallel, then running imagemin. This will come in handy as the build process grows.

* A typo in the Watch tasks was, unsurprisingly, throwing an error. Now fixed.