### PR TITLE
feat(*): update production flag syntax for Devops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ scss-lint-report.xml
 
 # Hide generated files
 /public/_*
+/public/*.css
 !/public/_img # This is not ignored.
 /public/var/*
 /public/packages/*

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,298 +3,316 @@
  */
 
 /*-----------------------------------------*\
-  VARIABLES
+	VARIABLES
 \*-----------------------------------------*/
 
 // Dependencies
 var $ = require('gulp-load-plugins')(),
-  gulp = require('gulp'),
-  del = require('del'),
-  fs = require('fs'),
-  lazypipe = require('lazypipe'),
-  argv = require('yargs').argv,
-  pngquant = require('imagemin-pngquant'),
-  runSequence = require('run-sequence'),
-  browserSync = require('browser-sync'),
-  reload = browserSync.reload,
+	gulp = require('gulp'),
+	del = require('del'),
+	fs = require('fs'),
+	lazypipe = require('lazypipe'),
+	argv = require('yargs').argv,
+	runSequence = require('run-sequence'),
+	browserSync = require('browser-sync'),
+	reload = browserSync.reload,
 
-  // Environments
-  production = !!(argv.production), // true if --prod flag is used
+	// Environments
+	production = !!(argv.production), // true if --production flag is used
 
-  // Base Paths
-  basePaths = {
-    src: 'assets/',
-    dest: 'public/'
-  },
+	// If not production load in pngquant
+	pngquant   = ! production ? require('imagemin-pngquant') : null,
 
-  // Assets Folder Paths
-  paths = {
-    scss: basePaths.src + 'scss/**/*.scss',
-    js: {
-      src: basePaths.src + 'js/src/**/*.js',
-      vendor: basePaths.src + 'js/vendor/*.js'
-    },
-    img: basePaths.src + 'img/**/*'
-  },
+	// Base Paths
+	basePaths = {
+		src: 'assets/',
+		dest: 'public/'
+	},
+
+	// Assets Folder Paths
+	paths = {
+		scss: basePaths.src + 'scss/**/*.scss',
+		js: {
+			src: basePaths.src + 'js/src/**/*.js',
+			vendor: basePaths.src + 'js/vendor/*.js'
+		},
+		img: basePaths.src + 'img/**/*'
+	},
+
+	svgPaths = {
+		images: {
+			src: basePaths.src + 'img/svg',
+			dest: '_img'
+		},
+		sprite: {
+			src: basePaths.src + 'img/svg/*.svg',
+			svgSymbols: '_img/svg/icons/icons.svg',
+		}
+};
 
 
 /*-----------------------------------------*\
-  ERROR NOTIFICATION
-  - Beep!
+	ERROR NOTIFICATION
+	- Beep!
 \*-----------------------------------------*/
 
 onError = function(err) {
-  $.notify.onError({
-    title: "Gulp",
-    subtitle: "Failure!",
-    message: "Error: <%= error.message %>",
-    sound: "Beep"
-  })(err);
-  this.emit('end');
+	$.notify.onError({
+		title: "Gulp",
+		subtitle: "Failure!",
+		message: "Error: <%= error.message %>",
+		sound: "Beep"
+	})(err);
+	this.emit('end');
 };
 
 
 /*-----------------------------------------*\
-  BROWSER SYNC
-  - View project at test.dev:3000
+	BROWSER SYNC
+	- View project at test.dev:3000
 \*-----------------------------------------*/
 
 gulp.task('browser-sync', function() {
-  browserSync({
-    proxy: "test.dev",
-    notify: false
-  });
+	browserSync({
+		proxy: "test.dev",
+		notify: false
+	});
 });
 
 
 /*-----------------------------------------*\
-   STYLES TASK
-   - Catch errors via gulp-plumber
-   - Compile Sass
-   - Vendor prefix
-   - Output unminified CSS for debugging
-   - Rename
-   - Minify
-   - Output minified CSS
+	 STYLES TASK
+	 - Catch errors via gulp-plumber
+	 - Compile Sass
+	 - Vendor prefix
+	 - Output unminified CSS for debugging
+	 - Rename
+	 - Minify
+	 - Output minified CSS
 \*-----------------------------------------*/
 
 gulp.task('styles', function () {
-  return gulp.src(paths.scss)
-    .pipe( $.plumber({errorHandler: onError}) )
-    .pipe($.sass({ style: 'expanded', }))
-    .pipe( $.autoprefixer('last 2 version') )
-    .pipe( gulp.dest(basePaths.dest) )
-    .pipe( $.rename({ suffix: '.min' }) )
-    .pipe( $.minifyCss() )
-    .pipe( gulp.dest(basePaths.dest) )
-    .pipe( $.size({title: 'Styles'}));
+	return gulp.src(paths.scss)
+		.pipe( $.plumber({errorHandler: onError}) )
+		.pipe($.sass({ style: 'expanded', }))
+		.pipe( $.autoprefixer('last 2 version') )
+		.pipe( gulp.dest(basePaths.dest + '_css') )
+		.pipe( $.rename({ suffix: '.min' }) ) // Remove to generate style.css for WordPress
+		.pipe( $.minifyCss() )
+		.pipe( gulp.dest(basePaths.dest) )
+		.pipe( $.size({title: 'Styles'}));
 });
 
 /*-----------------------------------------*\
-  SASS LINTING
-  - Keep your code squeaky clean
+	SASS LINTING
+	- Keep your code squeaky clean
 \*-----------------------------------------*/
 
 gulp.task('lint', function() {
-  return gulp.src(paths.scss)
-  .pipe( $.plumber({errorHandler: onError}) )
-  .pipe( $.scssLint( {
-    'bundleExec': true,
-    'config': '.scss-lint.yml',
-    'reporterOutput': 'scss-lint-report.xml'
-  }));
+	return gulp.src(paths.scss)
+	.pipe( $.plumber({errorHandler: onError}) )
+	.pipe( $.scssLint( {
+		'bundleExec': true,
+		'config': '.scss-lint.yml',
+		'reporterOutput': 'scss-lint-report.xml'
+	}));
 });
 
 
 /*-----------------------------------------*\
-   SCRIPTS TASK
-   - Catch errors via gulp-plumber
-   - Hint
-   - Concatenate assets/js into core.js
-   - Output unminified JS for debugging
-   - Minify
-   - Rename
-   - Output minified JS
+	 SCRIPTS TASK
+	 - Catch errors via gulp-plumber
+	 - Hint
+	 - Concatenate assets/js into core.js
+	 - Output unminified JS for debugging
+	 - Minify
+	 - Rename
+	 - Output minified JS
 \*-----------------------------------------*/
 
-gulp.task('scripts',function(){
-  gulp.src(paths.js.src)
-  .pipe( $.if(!production, $.plumber({errorHandler: onError}) ))
-  .pipe( $.if(!production, $.jshint() ))
-  .pipe( $.if(!production, $.jshint.reporter('default') ))
-  .pipe( $.concat('core.js') )
-  .pipe( gulp.dest(basePaths.dest + 'javascript') )
-  .pipe( $.uglify() )
-  .pipe( $.rename({ suffix: '.min' }) )
-  .pipe( gulp.dest(basePaths.dest + 'javascript') )
-  .pipe( $.size({title: 'Scripts'}));
+gulp.task('scripts', function(){
+	var gulpTasks = gulp.src([paths.js.src, paths.js.vendor])
+		.pipe( $.plumber({errorHandler: onError}) )
+
+	if ( ! production )
+	{
+		gulpTasks = gulpTasks.pipe( $.jshint() )
+			.pipe( $.jshint.reporter('default') );
+	}
+
+	return gulpTasks
+		.pipe( $.concat('core.js') )
+		.pipe( gulp.dest(basePaths.dest + '_js') )
+		.pipe( $.uglify() )
+		.pipe( $.rename({ suffix: '.min' }) )
+		.pipe( gulp.dest(basePaths.dest + '_js') )
+		.pipe( $.size({title: 'Scripts'}));
 });
 
 
 /*-----------------------------------------*\
-   VENDOR SCRIPTS TASK
-   - Leave vendor scripts intact
-   - Minify
-   - Output minified scripts
+	 VENDOR SCRIPTS TASK
+	 - Leave vendor scripts intact
+	 - Minify
+	 - Output minified scripts
 \*-----------------------------------------*/
 
 gulp.task('vendorScripts',function(){
-  return gulp.src(paths.js.vendor)
-  .pipe($.uglify())
-  .pipe(gulp.dest(basePaths.dest + 'javascript'))
-  .pipe($.size({title: 'Vendor Scripts'}));
+	return gulp.src(paths.js.vendor)
+	.pipe($.uglify())
+	.pipe(gulp.dest(basePaths.dest + '_js'))
+	.pipe($.size({title: 'Vendor Scripts'}));
 });
 
 
 /*-----------------------------------------*\
-   IMAGE OPTIMISATION TASK
-   - Optimise only new images + SVGs
-   - Output
+	 IMAGE OPTIMISATION TASK
+	 - Optimise only new images + SVGs
+	 - Output
 \*-----------------------------------------*/
 
 gulp.task('imgmin', function () {
-  return gulp.src(paths.img)
-    .pipe( $.cache( $.imagemin({
-        progressive: true,
-        use: [ pngquant() ]
-      })))
-    .pipe( gulp.dest(basePaths.dest + 'images'));
+	return gulp.src(paths.img)
+		.pipe( $.cache( $.imagemin({
+				progressive: true,
+				use: [ pngquant() ]
+			})))
+		.pipe( gulp.dest(basePaths.dest + '_img'));
 });
 
 
 /*-----------------------------------------*\
-   SVG ICONS TASKS
-   - Config
-   - Create Symbol Sprites
-   - Create and add Symbol ID (id="icon-example")
-   - Create icon library preview page
-   - Output compiled icon library
-   - Inject into page
+	 SVG ICONS TASKS
+	 - Config
+	 - Create Symbol Sprites
+	 - Create and add Symbol ID (id="icon-example")
+	 - Create icon library preview page
+	 - Output compiled icon library
+	 - Inject into page
 
-   NB: Imgmin optimises all SVGs, then
-   outputs them to the _img folder.
-   So we have the icon library and the
-   individual SVGs at ourt disposal.
+	 NB: Imgmin optimises all SVGs, then
+	 outputs them to the _img folder.
+	 So we have the icon library and the
+	 individual SVGs at ourt disposal.
 \*-----------------------------------------*/
-
-var svgPaths = {
-  images: {
-    src: basePaths.src + 'img/svg',
-    dest: '_img'
-  },
-  sprite: {
-    src: basePaths.src + 'img/svg/*.svg',
-    svgSymbols: '_img/svg/icons/icons.svg',
-  }
-};
 
 // SVG Symbols Task
 // Create SVG Symbols for icons.
 gulp.task('svgSymbols', function () {
-  return gulp.src(svgPaths.sprite.src)
-    .pipe(stripAttrs())
-    .pipe($.svgSprite(
-      {
-        mode        : {
-          symbol      : {
-          prefix      : ".icon-%s",
-          dimensions  : "%s",
-          sprite      : "svg/icons/icons.svg",
-          dest        : svgPaths.images.dest,
-          inline      : true,
-          "example": {
-            "dest": "svg/icons/icons-preview.html"
-            }
-          }
-      },
-        svg                     : {
-          dimensionAttributes : false
-        }
-      }
-    ))
-    .pipe(gulp.dest(basePaths.dest))
-    .pipe($.size({title: 'SVG Symbols'}));
-  });
+	return gulp.src(svgPaths.sprite.src)
+		.pipe(stripAttrs())
+		.pipe($.svgSprite(
+			{
+				mode        : {
+					symbol      : {
+					prefix      : ".icon-%s",
+					dimensions  : "%s",
+					sprite      : "svg/icons/icons.svg",
+					dest        : svgPaths.images.dest,
+					inline      : true,
+					"example": {
+						"dest": "svg/icons/icons-preview.html"
+						}
+					}
+			},
+				svg                     : {
+					dimensionAttributes : false
+				}
+			}
+		))
+		.pipe(gulp.dest(basePaths.dest))
+		.pipe($.size({title: 'SVG Symbols'}));
+	});
 
 // SVG Document Injection
 // Inject SVG <symbol> block just after opening <body> tag.
 gulp.task('inject', function () {
-  var symbols = gulp.src(basePaths.dest + svgPaths.sprite.svgSymbols);
+	var symbols = gulp.src(basePaths.dest + svgPaths.sprite.svgSymbols);
 
-  function fileContents (filePath, file) {
-    return file.contents.toString();
-  }
+	function fileContents (filePath, file) {
+		return file.contents.toString();
+	}
 
-  return gulp.src( basePaths.dest + 'index.php')
-    .pipe($.inject(symbols, { transform: fileContents }))
-    .pipe(gulp.dest( basePaths.dest ));
+	return gulp.src( basePaths.dest + 'index.php')
+		.pipe($.inject(symbols, { transform: fileContents }))
+		.pipe(gulp.dest( basePaths.dest ));
 });
-
 
 // Run all SVG tasks
 gulp.task('svg', function(cb) {
-  runSequence('svgSymbols', 'inject', cb);
+	runSequence('svgSymbols', 'inject', cb);
 });
 
 
 /*-----------------------------------------*\
-   DEV TASK
-   - Speedy!
+	 DEV TASK
+	 - Speedy!
 \*-----------------------------------------*/
 
 gulp.task('dev', function() {
-  gulp.start('scripts', 'styles');
+	gulp.start('scripts', 'styles');
 });
 
 
 /*-----------------------------------------*\
-   CLEAN OUTPUT DIRECTORIES
+	 CLEAN OUTPUT DIRECTORIES
 \*-----------------------------------------*/
 
-gulp.task('clean', function() {
-  del([basePaths.dest + 'javascript', basePaths.dest + 'images'], { read: false });
+gulp.task('clean', function(cb) {
+	if ( ! production )
+		return del([
+			basePaths.dest + '_*'
+		], { read: false }, cb)
+	else
+		return del([
+			basePaths.dest + '_*',
+			'!' + basePaths.dest + '_img'
+		], { read: false }, cb)
 });
 
 /*-----------------------------------------*\
-   CLEAR CACHE
+	 CLEAR CACHE
 \*-----------------------------------------*/
 
 gulp.task('clear', function (done) {
-  return $.cache.clearAll(done);
+	return $.cache.clearAll(done);
 });
 
 /*-----------------------------------------*\
-   MANUAL DEFAULT TASK
-   - Does everything
-   - Tasks in array run in parralel
+	 MANUAL DEFAULT TASK
+	 - Does everything
+	 - Tasks in array run in parralel
 \*-----------------------------------------*/
 
 gulp.task('default', ['clean'], function(cb) {
-  runSequence('styles', ['scripts', 'vendorScripts', 'imgmin'], 'svg', cb);
+	if ( ! production )
+		runSequence('imgmin', ['styles', 'scripts', 'vendorScripts'], 'svg', cb);
+	else
+		runSequence(['styles', 'scripts', 'vendorScripts'], cb);
 });
 
 /*-----------------------------------------*\
-   WATCH
-   - Watch assets & public folder
-   - Auto-reload browsers
+	 WATCH
+	 - Watch assets & public folder
+	 - Auto-reload browsers
 \*-----------------------------------------*/
 
 gulp.task('watch', ['browser-sync'], function() {
-  gulp.watch(paths.scss, ['styles', reload]);
-  gulp.watch(paths.js.src, ['scripts', reload]);
-  gulp.watch([basePaths.dest + '*.html', basePaths.dest + '*.php'], reload);
+	gulp.watch(paths.scss, ['styles', reload]);
+	gulp.watch(paths.js.src, ['scripts', reload]);
+	gulp.watch([basePaths.dest + '*.html', basePaths.dest + '*.php'], reload);
 });
 
 /*-----------------------------------------*\
-   CUSTOM PIPES
-   - Any pipes used more than once
+	 CUSTOM PIPES
+	 - Any pipes used more than once
 \*-----------------------------------------*/
 
 // Strips attributes from SVGs
 var stripAttrs = lazypipe()
-  .pipe( $.cheerio, {
-    run: function ($) {
-      $('[fill]').removeAttr('fill');
-    },
-    parserOptions: { xmlMode: true }
-  });
+	.pipe( $.cheerio, {
+		run: function ($) {
+			$('[fill]').removeAttr('fill');
+		},
+		parserOptions: { xmlMode: true }
+	});


### PR DESCRIPTION
Gulpfile updated to include new production flag syntax following a request from Devops. Also, removing imagemin and SVG tasks from the main production task (`gulp --production`) as we're now committed compressed images etc.

Standardised the naming conventions of the folders, just to keep things consistent. Obviously, these are all super-easy to change on a project basis. So, for now, all generated folders are prefixed with an underscore. 